### PR TITLE
Adapted code for compilation of Qt on OS X 10.7 - 10.9.

### DIFF
--- a/CASH-qt.pro
+++ b/CASH-qt.pro
@@ -5,7 +5,6 @@ VERSION = 1.2.0
 # INCLUDEPATH += src src/json src/qt /usr/include/mach /sw/include/db4
 # for OS X 10.8, it may only be necessary to point to the berkely db 4.8 library
 INCLUDEPATH += src src/json src/qt
-QT += network
 DEFINES += QT_GUI
 DEFINES += BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
 CONFIG += no_include_pwd

--- a/CASH-qt.pro
+++ b/CASH-qt.pro
@@ -1,6 +1,9 @@
 TEMPLATE = app
 TARGET = CASH-qt
 VERSION = 1.2.0
+# for OS X 10.7, it is necessary to point to the system includes and to the berkely db 4.8 library
+# INCLUDEPATH += src src/json src/qt /usr/include/mach /sw/include/db4
+# for OS X 10.8, it may only be necessary to point to the berkely db 4.8 library
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += QT_GUI
@@ -12,23 +15,24 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
 }
 
-# UNCOMMENT THIS SECTION TO BUILD ON WINDOWS
-#windows:LIBS += -lshlwapi
-#LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
-#LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
-#windows:LIBS += -lws2_32 -lole32 -loleaut32 -luuid -lgdi32
-#LIBS += -lboost_system-mgw48-mt-s-1_60 -lboost_filesystem-mgw48-mt-s-1_60 -lboost_program_options-mgw48-mt-s-1_60 -lboost_thread-mgw48-mt-s-1_60
-#BOOST_LIB_SUFFIX=-mgw48-mt-s-1_60
-#BOOST_INCLUDE_PATH=C:/deps/boost_1_60_0
-#BOOST_LIB_PATH=C:/deps/boost_1_60_0/stage/lib
-#BDB_INCLUDE_PATH=c:/deps/db-4.8.30.NC/build_unix
-#BDB_LIB_PATH=c:/deps/db-4.8.30.NC/build_unix
-#OPENSSL_INCLUDE_PATH=c:/deps/openssl-1.0.2g/include
-#OPENSSL_LIB_PATH=c:/deps/openssl-1.0.2g
-#MINIUPNPC_LIB_PATH=c:/deps/miniupnpc
-#MINIUPNPC_INCLUDE_PATH=c:/deps/miniupnpc
-#QRENCODE_INCLUDE_PATH=C:/deps/qrencode-3.4.4
-#QRENCODE_LIB_PATH=C:/deps/qrencode-3.4.4/.libs
+windows:win32 {
+windows:LIBS += -lshlwapi
+LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
+LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
+windows:LIBS += -lws2_32 -lole32 -loleaut32 -luuid -lgdi32
+LIBS += -lboost_system-mgw48-mt-s-1_60 -lboost_filesystem-mgw48-mt-s-1_60 -lboost_program_options-mgw48-mt-s-1_60 -lboost_thread-mgw48-mt-s-1_60
+BOOST_LIB_SUFFIX=-mgw48-mt-s-1_60
+BOOST_INCLUDE_PATH=C:/deps/boost_1_60_0
+BOOST_LIB_PATH=C:/deps/boost_1_60_0/stage/lib
+BDB_INCLUDE_PATH=c:/deps/db-4.8.30.NC/build_unix
+BDB_LIB_PATH=c:/deps/db-4.8.30.NC/build_unix
+OPENSSL_INCLUDE_PATH=c:/deps/openssl-1.0.2g/include
+OPENSSL_LIB_PATH=c:/deps/openssl-1.0.2g
+MINIUPNPC_LIB_PATH=c:/deps/miniupnpc
+MINIUPNPC_INCLUDE_PATH=c:/deps/miniupnpc
+QRENCODE_INCLUDE_PATH=C:/deps/qrencode-3.4.4
+QRENCODE_LIB_PATH=C:/deps/qrencode-3.4.4/.libs
+}
 
 # for boost 1.37, add -mt to the boost libraries
 # use: qmake BOOST_LIB_SUFFIX=-mt
@@ -46,8 +50,12 @@ UI_DIR = build
 
 # use: qmake "RELEASE=1"
 contains(RELEASE, 1) {
-    # Mac: compile for maximum compatibility (10.5, 32-bit)
-    macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+# Mac: no longer recommended to compile for maximum compatibility (10.5, 32-bit)
+# macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch i386 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+# If max compatibility fails, work up the versions or simply omit for installed version
+# macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.7 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.7.sdk
+# Build only for current OS X version
+macx:QMAKE_CXXFLAGS += -arch x86_64
 
     !windows:!macx {
         # Linux: static link

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -52,6 +52,8 @@ Mac OS X
 
 - Download and install the `Qt Mac OS X SDK`_. It is recommended to also install Apple's Xcode with UNIX tools.
 
+  The recommended version of Qt Creator is 2.8.1.
+
 - Download and install `MacPorts`_.
 
 - Execute the following commands in a terminal to get the dependencies:
@@ -61,7 +63,24 @@ Mac OS X
 	sudo port selfupdate
 	sudo port install boost db48 miniupnpc
 
+
 - Open the .pro file in Qt Creator and build as normal (cmd-B)
+
+  **NOTE** It may be necessary to explicitly specify the compiler from in Qt Creator.
+  In QT Creator 2.8.1, click the Projects icon on the left-hand tool bar,
+  click "Build & Run" in the window that opens, then click "Manage Kits"
+  in the toolbar, then click "Kits" in the new tool bar,
+  click the selection below "Manual" in the listbox,
+  then select the compiler "Clang (x86 64 bit in /usr/bin)" and hit "Apply" then hit "OK".
+
+  **NOTE ALSO** It may be necessary to explicitly set include paths to the
+  system includes (e.g. ``/usr/include/mach``) and/or to the Berkely DB 4.8.
+
+  For example, the latter might be in ``/opt/local/include/db48`` if from mac ports.
+
+  Setting includes can be done by editing the .pro file and modifying the line
+  that starts with "INCLUDEPATH" according to the example.
+
 
 .. _`Qt Mac OS X SDK`: http://qt.nokia.com/downloads/sdk-mac-os-cpp
 .. _`MacPorts`: http://www.macports.org/install.php

--- a/src/scrypt-x86_64.S
+++ b/src/scrypt-x86_64.S
@@ -175,7 +175,7 @@
 
 
 	.text
-	.align 16  # OSX dislikes .align 32
+	.align 32
 gen_salsa8_core:
 	# 0: %rdx, %rdi, %rcx, %rsi
 	movq	8(%rsp), %rdi
@@ -274,7 +274,7 @@ gen_salsa8_core:
 
 
 	.text
-	.align 16  # OSX dislikes .align 32
+	.align 32
 	.globl scrypt_core
 	.globl _scrypt_core
 scrypt_core:
@@ -525,7 +525,7 @@ gen_scrypt_core_loop2:
 	xmm_salsa8_core_doubleround(); \
 
 
-	.align 16  # OSX dislikes .align 32
+	.align 32
 xmm_scrypt_core:
 	# shuffle 1st block into %xmm8-%xmm11
 	movl	60(%rdi), %edx
@@ -837,7 +837,7 @@ xmm_scrypt_core_loop2:
 
 
 	.text
-	.align 16  # OSX dislikes .align 32
+	.align 32
 	.globl scrypt_best_throughput
 	.globl _scrypt_best_throughput
 scrypt_best_throughput:
@@ -999,7 +999,7 @@ scrypt_best_throughput_exit:
 
 
 	.text
-	.align 16  # OSX dislikes .align 32
+	.align 32
 	.globl scrypt_core_2way
 	.globl _scrypt_core_2way
 scrypt_core_2way:
@@ -1461,7 +1461,7 @@ scrypt_core_2way_loop2:
 
 
 	.text
-	.align 16  # OSX dislikes .align 32
+	.align 32
 	.globl scrypt_core_3way
 	.globl _scrypt_core_3way
 scrypt_core_3way:

--- a/src/scrypt-x86_64.S
+++ b/src/scrypt-x86_64.S
@@ -175,7 +175,7 @@
 
 
 	.text
-	.align 32
+	.align 16  # OSX dislikes .align 32
 gen_salsa8_core:
 	# 0: %rdx, %rdi, %rcx, %rsi
 	movq	8(%rsp), %rdi
@@ -274,7 +274,7 @@ gen_salsa8_core:
 
 
 	.text
-	.align 32
+	.align 16  # OSX dislikes .align 32
 	.globl scrypt_core
 	.globl _scrypt_core
 scrypt_core:
@@ -525,7 +525,7 @@ gen_scrypt_core_loop2:
 	xmm_salsa8_core_doubleround(); \
 
 
-	.align 32
+	.align 16  # OSX dislikes .align 32
 xmm_scrypt_core:
 	# shuffle 1st block into %xmm8-%xmm11
 	movl	60(%rdi), %edx
@@ -837,7 +837,7 @@ xmm_scrypt_core_loop2:
 
 
 	.text
-	.align 32
+	.align 16  # OSX dislikes .align 32
 	.globl scrypt_best_throughput
 	.globl _scrypt_best_throughput
 scrypt_best_throughput:
@@ -999,7 +999,7 @@ scrypt_best_throughput_exit:
 
 
 	.text
-	.align 32
+	.align 16  # OSX dislikes .align 32
 	.globl scrypt_core_2way
 	.globl _scrypt_core_2way
 scrypt_core_2way:
@@ -1461,7 +1461,7 @@ scrypt_core_2way_loop2:
 
 
 	.text
-	.align 32
+	.align 16  # OSX dislikes .align 32
 	.globl scrypt_core_3way
 	.globl _scrypt_core_3way
 scrypt_core_3way:


### PR DESCRIPTION
**CASH-qt.pro:**
-Changed comment block for windows into a proper conditional block.
-Added example for INCLUDEPATH and some examples for QMAKE_CXXFLAGS.
-No need to modify CASH-qt.pro any more to build on Windows, Linux or Mac.
-Remove QT += network as it's not needed

**readme-qt.rst:**
-Added instructions for less painful build with QT Creator.

**scrypt-x86_64.S:**
-Fixed 32 bit alignment to 16 bit alignment for OS X 10.9, which
seems to reject 32 bit alignment.
 ***_has been revert to 32 bit alignment. If someone want to build for OS X 10.9 they will need to modify this file themselves (view commit d51c8c6)**_
